### PR TITLE
Resolve issue #23, support .stx namespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "btc.us",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "dependencies": {
         "compression": "^1.7.1",
         "polka": "next",

--- a/src/components/domainsearchfield.svelte
+++ b/src/components/domainsearchfield.svelte
@@ -24,7 +24,9 @@
 			return;
 			}
 		searching = true;
-		let current_value = value;
+		// TODO this whole codebase is essentially hardcoded to only support .btc
+		// There should be a user-selectable namespace option
+		const current_value = value + ".btc";
 		name_available(current_value).then(result =>
 			{
 			if (!searching)

--- a/src/routes/get/[domain_name].svelte
+++ b/src/routes/get/[domain_name].svelte
@@ -2,7 +2,7 @@
 	import {stores,goto} from '@sapper/app';
 	import {get} from 'svelte/store';
 	
-	import {address_name,available as name_available,DOMAIN_NAMESPACE,DOMAIN_COST_STX,DOMAIN_RENEWAL_PERIOD_YEARS} from '../../lib/nameservice';
+	import {address_name,available as name_available,DOMAIN_COST_STX,DOMAIN_RENEWAL_PERIOD_YEARS} from '../../lib/nameservice';
 	import {
 		domain_purchase_prepare,
 		domain_purchase_preorder,
@@ -21,8 +21,6 @@
 	
 	const {page} = stores();
 	let domain_name = get(page).params.domain_name.toLowerCase();
-	if (domain_name.slice(-DOMAIN_NAMESPACE.length-1) !== `.${DOMAIN_NAMESPACE}`)
-		domain_name += `.${DOMAIN_NAMESPACE}`;
 	
 	let step = 0;
 	let payment_method = 'stx';

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -93,7 +93,7 @@
 <header>
 	<div>
 		<h1>{$t('page.index.heading')}</h1>
-		<DomainSearchField small={$width_705} on:submit={result => result.detail.available && goto('/get/'+result.detail.name+'.btc')}/>
+		<DomainSearchField small={$width_705} on:submit={result => result.detail.available && goto('/get/'+result.detail.name)}/>
 		<p>{@html $t('page.index.sub_heading')}</p>
 	</div>
 </header>

--- a/src/routes/manage/index.svelte
+++ b/src/routes/manage/index.svelte
@@ -482,9 +482,11 @@
 									<Loading/>
 								{:then resolve}
 									<span class="status active">{$t('page.manage.active')}</span>
-									{#await block_height_timestamp(resolve['lease-ending-at'].value.value) then timestamp}
-										{$t('page.manage.active_until',{values:{date:format_date(timestamp)}})}
-									{/await}
+									{#if resolve['lease-ending-at'] && resolve['lease-ending-at'].value}
+										{#await block_height_timestamp(resolve['lease-ending-at'].value.value) then timestamp}
+											{$t('page.manage.active_until',{values:{date:format_date(timestamp)}})}
+										{/await}
+									{/if}
 								{/await}
 							</td>
 							<td></td>


### PR DESCRIPTION
This resolves issue #23 

I can now transfer .stx namespaces.

List of valid namespaces for transferring is stored in the following variable:
```
export const VALID_NAMESPACES = ['btc', 'stx'];
```
I did not do any sort of proper regression testing so it is very likely I broke something somewhere, but for what its worth I can still go through the registration process of a new .btc without issue.

The rest of the codebase, and specifically the order/registration flow, is all essentially hardcoded to only support .btc.
Somebody should refactor it.